### PR TITLE
add extra info

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -2,7 +2,7 @@
   "name": "green-tunnel",
   "version": "3.1.2",
   "description": "bypasses DPI (Deep Packet Inspection) systems found in many ISPs (Internet Service Providers)",
-  "homepage": "https://github.com/SadeghHayeri/GreenTunnel"
+  "homepage": "https://github.com/SadeghHayeri/GreenTunnel",
   "main": "main.js",
   "scripts": {
     "test": "electron .",

--- a/gui/package.json
+++ b/gui/package.json
@@ -2,6 +2,7 @@
   "name": "green-tunnel",
   "version": "3.1.2",
   "description": "bypasses DPI (Deep Packet Inspection) systems found in many ISPs (Internet Service Providers)",
+  "homepage": "https://github.com/SadeghHayeri/GreenTunnel"
   "main": "main.js",
   "scripts": {
     "test": "electron .",
@@ -12,7 +13,7 @@
     "linux-installer": "electron-installer-debian --name green-tunnel --src release-builds/green-tunnel-linux-x64/ --arch amd64 --config installers/linux/debian.json",
     "windows-installer": "node installers/windows/createinstaller.js"
   },
-  "author": "",
+  "author": "Sadegh Hayeri <hayerisadegh@gmail.com> (https://github.com/SadeghHayeri/)",
   "license": "ISC",
   "devDependencies": {
     "electron": "^4.1.5",


### PR DESCRIPTION
Added extra author information to avoid possible dpkg problems like which errors i get from apt and dpkg in debian 10.

```
$ sudo apt-get autoremove
...
unnecessary part
...
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 10744 package 'green-tunnel':
 missing 'Maintainer' field
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 10744 package 'green-tunnel':
 missing 'Maintainer' field
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 10744 package 'green-tunnel':
 missing 'Maintainer' field
(10 more same error)
```