### PR TITLE
FIX: Upgrade to docker/build-push-action@v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve tag
+        id: retrieve
         run: |
           DOCKER_IMAGE=sadeghhayeri/green-tunnel
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
+          fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo "TAGS=$TAGS" >> $GITHUB_ENV
+          echo ::set-output name=tags::${TAGS}
       - uses: actions/checkout@master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -42,7 +44,7 @@ jobs:
         with:
           file: Dockerfile
           push: true
-          tags: ${TAGS}
+          tags: ${{ steps.retrieve.outputs.tags }}
 
   publish-docker-hub-for-arm:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           file: Dockerfile
           push: true
-          tags: ${{ steps.retrieve.outputs.tags }}
+          tags: ${{ steps.retrieve.outputs.tags }},sadeghhayeri/green-tunnel:latest
 
   publish-docker-hub-for-arm:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          repository: sadeghhayeri/green-tunnel
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_with_ref: true
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          push: true
+          tags: sadeghhayeri/green-tunnel
 
   publish-docker-hub-for-arm:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,13 @@ jobs:
   publish-docker-hub:
     runs-on: ubuntu-latest
     steps:
+      - name: Retrieve tag
+        run: |
+          DOCKER_IMAGE=sadeghhayeri/green-tunnel
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
       - uses: actions/checkout@master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -35,7 +42,7 @@ jobs:
         with:
           file: Dockerfile
           push: true
-          tags: sadeghhayeri/green-tunnel
+          tags: ${TAGS}
 
   publish-docker-hub-for-arm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`docker/build-push-action@v1` has been deprecated.

The only problem is `tag_with_ref: true` which is missing in version 2 and should be changed like this:
https://github.com/docker/build-push-action/blob/master/UPGRADE.md#tags-with-ref-and-git-labels

I haven't use the methods specified in the link myself, so I have not tested them somewhere.

I'm going to add them when I had more time.