### PR TITLE
Changing several configuration to making GH Action working to making new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish
@@ -69,10 +69,10 @@ jobs:
     runs-on: macOS-latest
     needs: [publish-npm]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install Dependencies
         working-directory: ./gui
@@ -110,10 +110,10 @@ jobs:
     runs-on: windows-latest
     needs: [publish-npm]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Update GreenTunnel Core
         working-directory: ./gui
@@ -147,10 +147,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-npm]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install Dependencies
         working-directory: ./gui


### PR DESCRIPTION
I was looking the release page and it seem the page not updating with new commit. So I decide to testing on my fork and building new configuration to make sure that GH Action working well.

Several note that I need to declare here, Checkout V1 is not working anymore with GitHub, this is can be a reason why your GH Action not working well when pushing new commit and not showing new release.
You can making release with help like cron job, IDK how but if you bit laze you can check on SE for info.
Last, You project is cool man...