### PR TITLE
Support for unencrypted DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Options:
   --port          port address to bind proxy server     [number] [default: 8000]
   --dns-type               [string] [choices: "https", "tls"] [default: "https"]
   --dns-server        [string] [default: "https://cloudflare-dns.com/dns-query"]
+  --dns-ip        IP address for unencrypted DNS  [string][default: "127.0.0.1"]
+  --dns-port      Port for unencrypted DNS                [number] [default: 53]
   --silent, -s    run in silent mode                  [boolean] [default: false]
   --verbose, -v   debug mode                              [string] [default: ""]
   --system-proxy  automatic set system-proxy           [boolean] [default: true]

--- a/bin/gt.js
+++ b/bin/gt.js
@@ -7,11 +7,11 @@ const ora = require('ora');
 const debug = require('debug');
 const yargs = require('yargs');
 const pkg = require('../package.json');
-const {Proxy, config, getLogger} = require('../src/index.cjs');
+const { Proxy, config, getLogger } = require('../src/index.cjs');
 
 const logger = getLogger('cli');
 
-const {argv} = yargs
+const { argv } = yargs
 	.usage('Usage: green-tunnel [options]')
 	.usage('Usage: gt [options]')
 	.alias('help', 'h')
@@ -37,13 +37,23 @@ const {argv} = yargs
 
 	.option('dns-type', {
 		type: 'string',
-		choices: ['https', 'tls'],
+		choices: ['https', 'tls', 'unencrypted'],
 		default: config.dns.type,
 	})
 
 	.option('dns-server', {
 		type: 'string',
 		default: config.dns.server,
+	})
+
+	.option('dns-ip', {
+		type: 'string',
+		default: config.dns.ip,
+	})
+
+	.option('dns-port', {
+		type: 'number',
+		default: config.dns.port,
 	})
 
 	.option('silent', {
@@ -113,7 +123,9 @@ async function main() {
 		httpsOnly: argv['https-only'],
 		dns: {
 			type: argv['dns-type'],
-			server: argv['dns-server']
+			server: argv['dns-server'],
+			ip: argv['dns-ip'],
+			port: argv['dns-port']
 		},
 		source: 'CLI',
 	});
@@ -138,12 +150,12 @@ async function main() {
 	process.on('unhandledRejection', errorTrap);
 	process.on('uncaughtException', errorTrap);
 
-	await proxy.start({setProxy: argv['system-proxy']});
+	await proxy.start({ setProxy: argv['system-proxy'] });
 
 	if (!argv['silent'] && !argv['verbose']) {
 		clear();
 		printBanner();
-		updateNotifier({pkg}).notify();
+		updateNotifier({ pkg }).notify();
 		printAlert(proxy);
 		showSpinner();
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+    },
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
@@ -418,6 +423,14 @@
             "safe-buffer": "^5.1.1"
           }
         },
+        "dns-socket": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz",
+          "integrity": "sha512-M0WkByoJ/mTm+HtwBQLsRJPe5uGIC/lYVOp+s6ZzhbZ5iq4GxjFyxYPQhB85dgCLvVb43aJQXHDC9aUgyKGc/Q==",
+          "requires": {
+            "dns-packet": "^4.1.0"
+          }
+        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -451,20 +464,19 @@
       }
     },
     "dns-socket": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz",
-      "integrity": "sha512-M0WkByoJ/mTm+HtwBQLsRJPe5uGIC/lYVOp+s6ZzhbZ5iq4GxjFyxYPQhB85dgCLvVb43aJQXHDC9aUgyKGc/Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
+      "integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
       "requires": {
-        "dns-packet": "^4.1.0"
+        "dns-packet": "^5.2.4"
       },
       "dependencies": {
         "dns-packet": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
-          "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
+          "integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
           "requires": {
-            "ip": "^1.1.5",
-            "safe-buffer": "^5.1.1"
+            "@leichtgewicht/ip-codec": "^2.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "debug": "^4.1.1",
     "dns-over-http": "^0.1.2",
     "dns-over-tls": "0.0.6",
+    "dns-socket": "^4.2.2",
     "esm": "^3.2.22",
     "is-docker": "^2.0.0",
     "lru-cache": "^5.1.1",

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,10 @@
 const config = {
-	ip: '0.0.0.0',
+	ip: '127.0.0.1',
 	port: 8000,
 	httpsOnly: false,
 	clientHelloMTU: 100,
 	dns: {
-		type: 'unencrypted', // 'tls' or 'https' or 'unencrypted'
+		type: 'https', // 'tls' or 'https' or 'unencrypted'
 		server: 'https://cloudflare-dns.com/dns-query',
 		ip: '127.0.0.1',
 		port: 53,

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,13 @@
 const config = {
-	ip: '127.0.0.1',
+	ip: '0.0.0.0',
 	port: 8000,
 	httpsOnly: false,
 	clientHelloMTU: 100,
 	dns: {
-		type: 'https', // 'tls' or 'https'
+		type: 'unencrypted', // 'tls' or 'https' or 'unencrypted'
 		server: 'https://cloudflare-dns.com/dns-query',
+		ip: '127.0.0.1',
+		port: 53,
 		cacheSize: 1000,
 	}
 };

--- a/src/dns/base.js
+++ b/src/dns/base.js
@@ -1,5 +1,5 @@
 import LRU from 'lru-cache';
-import {isIP} from 'validator';
+import { isIP } from 'validator';
 import getLogger from '../logger';
 import config from '../config';
 

--- a/src/dns/unencrypted.js
+++ b/src/dns/unencrypted.js
@@ -1,0 +1,25 @@
+import dnsSocket from 'dns-socket';
+import BaseDNS from './base';
+
+const socket = dnsSocket()
+
+export default class DNSOverHTTPS extends BaseDNS {
+  constructor(dnsIp, dnsPort) {
+    super();
+    this.dnsIp = dnsIp;
+    this.dnsPort = dnsPort;
+  }
+
+  _lookup(hostname) {
+    return new Promise((resolve, reject) => {
+      socket.query({
+        questions: [{
+          type: 'A',
+          name: hostname
+        }]
+      }, this.dnsPort, this.dnsIp, (err, res, query) => {
+        resolve(res.answers[0].data);
+      });
+    });
+  }
+}

--- a/src/dns/unencrypted.js
+++ b/src/dns/unencrypted.js
@@ -3,7 +3,7 @@ import BaseDNS from './base';
 
 const socket = dnsSocket()
 
-export default class DNSOverHTTPS extends BaseDNS {
+export default class DNSUnencrypted extends BaseDNS {
   constructor(dnsIp, dnsPort) {
     super();
     this.dnsIp = dnsIp;


### PR DESCRIPTION
This PR adds support for unencrypted IP:Port based DNS. It could be used to connect to a running instance of PiHole or AdGuard Home.