### PR TITLE
Set https proxy

### DIFF
--- a/src/utils/system-proxy.js
+++ b/src/utils/system-proxy.js
@@ -24,6 +24,8 @@ class LinuxSystemProxy extends SystemProxy {
 		await exec('gsettings set org.gnome.system.proxy mode manual');
 		await exec(`gsettings set org.gnome.system.proxy.http host ${ip}`);
 		await exec(`gsettings set org.gnome.system.proxy.http port ${port}`);
+		await exec(`gsettings set org.gnome.system.proxy.https host ${ip}`);
+		await exec(`gsettings set org.gnome.system.proxy.https port ${port}`);
 	}
 
 	static async unsetProxy() {


### PR DESCRIPTION
The HTTPS proxy in gnome doesn't set before and cause that tunnel doesn't work for HTTPS websites.
In this commit, the https proxy is set.