### PR TITLE
fix: Docker image name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
           echo "CLIENT_PORT=${CLIENT_PORT}" >> $GITHUB_ENV
 
       - name: Build docker image
-        run: docker build --no-cache --tag sadeghhayeri/greentunnel:${GITHUB_RUN_ID} .
+        run: docker build --no-cache --tag sadeghhayeri/green-tunnel:${GITHUB_RUN_ID} .
 
       - name: Run container
         run: |
-          DOCKERCONTAINER=$(docker run -p 127.0.0.1:${CLIENT_PORT}:8000 -d sadeghhayeri/greentunnel:${GITHUB_RUN_ID})
+          DOCKERCONTAINER=$(docker run -p 127.0.0.1:${CLIENT_PORT}:8000 -d sadeghhayeri/green-tunnel:${GITHUB_RUN_ID})
           sleep 5
           echo "DOCKERCONTAINER=${DOCKERCONTAINER}" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After installation, run with `gt` or `green-tunnel`.
 ### Docker
 
 ```bash
-docker run -p 8000:8000 sadeghhayeri/greentunnel
+docker run -p 8000:8000 sadeghhayeri/green-tunnel
 ```
 
 ---
@@ -105,13 +105,13 @@ gt --verbose 'green-tunnel:*'
 
 ```bash
 # Basic
-docker run -p 8000:8000 sadeghhayeri/greentunnel
+docker run -p 8000:8000 sadeghhayeri/green-tunnel
 
 # Custom port
-docker run -e PORT=9000 -p 9000:9000 sadeghhayeri/greentunnel
+docker run -e PORT=9000 -p 9000:9000 sadeghhayeri/green-tunnel
 
 # Run in background, restart on reboot
-docker run -d --restart unless-stopped -p 8000:8000 sadeghhayeri/greentunnel
+docker run -d --restart unless-stopped -p 8000:8000 sadeghhayeri/green-tunnel
 ```
 
 **Environment variables:**


### PR DESCRIPTION
The docker image name is wrong in the [README.md](https://github.com/SadeghHayeri/GreenTunnel/blob/3c100f85f3e0c1480b05fca1aab3ddf8b648a6ce/README.md) which causes the docker command to fail. Checking the Docker Hub [page](https://hub.docker.com/r/sadeghhayeri/green-tunnel) reviles that there is a `-` missing. This MR fixes this issue.

Also updated the docker image name in [test.yml](https://github.com/SadeghHayeri/GreenTunnel/blob/3c100f85f3e0c1480b05fca1aab3ddf8b648a6ce/.github/workflows/test.yml) to match the one in Docker Hub.